### PR TITLE
Fix missing definition for memcpy in FPCompare.h

### DIFF
--- a/FPCompare.h
+++ b/FPCompare.h
@@ -13,6 +13,8 @@
 
 #pragma once
 
+#include <memory.h> // memcpy
+
 // ==========================================================================
 // Copyright 2005, Google Inc.
 // All rights reserved.


### PR DESCRIPTION
compile error in my GCC project...