### PR TITLE
Fix compilation of release builds with -wall

### DIFF
--- a/CircVal.h
+++ b/CircVal.h
@@ -221,7 +221,7 @@ class CircValTester
     }
 
     // assert that 2 circular-values are almost equal
-    inline static void AssertCircAlmostEq(const CircVal<Type>& c1, const CircVal<Type>& c2)
+    inline static void AssertCircAlmostEq([[maybe_unused]]const CircVal<Type>& c1, [[maybe_unused]]const CircVal<Type>& c2)
     {
         assert(IsCircAlmostEq(c1, c2));
     }

--- a/FPCompare.h
+++ b/FPCompare.h
@@ -297,7 +297,7 @@ static bool IsAlmostEq(T x, T y)
 }
 
 // assert that 2 floating-points are almost equal
-[[maybe_unused]] static void AssertAlmostEq(const double f, const double g)
+[[maybe_unused]] static void AssertAlmostEq([[maybe_unused]]const double f, [[maybe_unused]]const double g)
 {
     assert(IsAlmostEq(f, g));
 }


### PR DESCRIPTION
For release builds, assert arguments are not referenced;.
Add [[maybe_unused]] for assert function parameters.